### PR TITLE
Fix vulnerability in angular-translate-once.

### DIFF
--- a/src/translate-once.js
+++ b/src/translate-once.js
@@ -66,7 +66,7 @@
         // queue the translation
         $translate(translationKey, translateValues).then(function (translation) {
           // update the element with the translation
-          element.html(translation);
+          element.text(translation);
 
           // if the flag for compiling is set, compile it
           if (attrs.hasOwnProperty('translateCompile')) {


### PR DESCRIPTION
Translate-once is calling element.html(translation), which poses a vulnerability if the key is not in the resource dictionary and contains malicious code (e.g. XSS attack.). 

So change the element.html(translate) to element.text(translate) can avoid this issue.